### PR TITLE
Unscrew invalid sudoers syntax

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,7 +20,7 @@ class homebrew (
   }
 
   sudoers::allowed_command{ 'cask_installer':
-    command          => 'usr/sbin/installer',
+    command          => '/usr/sbin/installer',
     user             => $facts['id'],
     require_password => false,
     require_exist    => false,


### PR DESCRIPTION
I blame https://github.com/halyard/puppet-homebrew/commit/af55c2424a3d9d5afc4ef39cdf4e9cac97dcb5cb